### PR TITLE
Add lock mechanism for idle state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ DATABASE_MIGRATIONS.md
 INSIGHTS_CONTEXT.md
 CLAUDE.md
 STARTER_PROMPT.md
+ROADMAP.md
 
 # TypeScript incremental build info
 *.tsbuildinfo

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
-import { app, BrowserWindow, dialog, ipcMain, Notification, Tray, Menu, safeStorage } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, Notification, Tray, Menu, safeStorage, powerMonitor } from 'electron'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
-import { initializeDatabase, processRecurringTransactions, processSavingsInterest, getDueReminders, openDatabase, rekeyDatabase, isUnlocked, hasPlaintextDbWithData, setAsidePlaintextDb, getSessionPassword } from './db'
+import { initializeDatabase, processRecurringTransactions, processSavingsInterest, getDueReminders, openDatabase, rekeyDatabase, isUnlocked, lockDatabase, hasPlaintextDbWithData, setAsidePlaintextDb, getSessionPassword } from './db'
 import { registerIpcHandlers } from './ipc'
 import { checkAndRunBackup } from './backup'
 import { loadPreferences, savePreferences, applyOpenAtLogin, AppPreferences } from './preferences'
@@ -50,7 +50,7 @@ let win: BrowserWindow | null;
 let tray: Tray | null = null;
 // Set to true by the tray "Quit" item so the window's close handler lets the app exit.
 let isQuitting = false;
-let appPreferences: AppPreferences = { minimizeToTray: false, openAtLogin: false };
+let appPreferences: AppPreferences = { minimizeToTray: false, openAtLogin: false, autoLockMinutes: 0 };
 
 function showWindow() {
   if (!win) {
@@ -395,6 +395,8 @@ function runReminderCheck() {
 function startRecurringTransactionsTask() {
   // Check every 1 minute
   setInterval(() => {
+    // Skip all DB-backed work while the session is locked (getDb() would throw).
+    if (!isUnlocked()) return;
     runReminderCheck();
     if (processRecurringTransactions()) {
       BrowserWindow.getAllWindows().forEach(w => w.webContents.send('recurring-processed'));
@@ -406,6 +408,21 @@ function startRecurringTransactionsTask() {
       BrowserWindow.getAllWindows().forEach(w => w.webContents.send('silent-backup-complete'));
     }
   }, 60 * 1000);
+}
+
+// Re-lock the database when the OS suspends or the screen locks, so an unlocked
+// session isn't left exposed while the user is away. The renderer is told via
+// 'app-locked' to show the master-password gate. NOTE: 'lock-screen' is
+// macOS/Windows only — on Linux a plain screen-lock fires no Electron event, so
+// there it relies on 'suspend' (sleep) plus the renderer's idle auto-lock.
+function registerPowerMonitorLock() {
+  const lockFromMain = () => {
+    if (!isUnlocked()) return;
+    lockSession();
+    BrowserWindow.getAllWindows().forEach(w => w.webContents.send('app-locked'));
+  };
+  powerMonitor.on('suspend', lockFromMain);
+  powerMonitor.on('lock-screen', lockFromMain);
 }
 
 // Background tasks (the 1-minute heartbeat) must start exactly once, and only
@@ -447,6 +464,15 @@ function canRemember(): boolean {
 // the next manual unlock). Used for 'session' and once a window has expired.
 function clearRemembered(): void {
   saveSecurity({ rememberedKey: null, rememberExpiry: null });
+}
+
+// Re-lock the session: drop the in-memory passphrase + close the DB, and clear any
+// remembered key. Clearing the key means a deliberate lock also defeats launch-time
+// auto-unlock — a restart then requires the password even within a still-valid
+// 'stay unlocked' window. Re-typing the password on unlock re-arms the window.
+function lockSession(): void {
+  lockDatabase();
+  clearRemembered();
 }
 
 // Apply a remember policy in one atomic write: encrypt the password with the OS
@@ -575,6 +601,14 @@ ipcMain.handle('auth:changePassword', (_event, oldPassword: string, newPassword:
   }
 });
 
+// Manual / idle lock from the renderer: clear the in-memory passphrase and re-lock
+// the DB so getDb() throws again. The renderer shows the gate; re-unlock goes
+// through auth:unlock (no auto-unlock, so the lock isn't immediately undone).
+ipcMain.handle('auth:lock', () => {
+  lockSession();
+  return { success: true };
+});
+
 if (app.isPackaged) {
   const gotTheLock = app.requestSingleInstanceLock()
 
@@ -601,6 +635,7 @@ if (app.isPackaged) {
 
       createWindow();
       createTray();
+      registerPowerMonitorLock();
     });
   }
 } else {
@@ -616,5 +651,6 @@ if (app.isPackaged) {
 
     createWindow();
     createTray();
+    registerPowerMonitorLock();
   });
 }

--- a/electron/preferences.ts
+++ b/electron/preferences.ts
@@ -8,11 +8,14 @@ export interface AppPreferences {
   minimizeToTray: boolean;
   // Launch OneFinance automatically when the user logs in.
   openAtLogin: boolean;
+  // Minutes of inactivity before the app auto-locks the database (0 = never).
+  autoLockMinutes: number;
 }
 
 const DEFAULTS: AppPreferences = {
   minimizeToTray: false,
   openAtLogin: false,
+  autoLockMinutes: 0,
 };
 
 function getPreferencesPath(): string {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -292,6 +292,13 @@ const electronAPI = {
   setRememberPolicy: (policy: RememberPolicy): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke("auth:setRememberPolicy", policy),
 
+  lock: (): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke("auth:lock"),
+
+  onAppLocked: (callback: () => void) => {
+    ipcRenderer.on("app-locked", callback);
+  },
+
   changeMasterPassword: (oldPassword: string, newPassword: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke("auth:changePassword", oldPassword, newPassword),
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, nextTick } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
 import { useFinanceStore } from "@/stores/finance";
 import { useSettingsStore } from "@/stores/settings";
+import { useAuthStore } from "@/stores/auth";
+import { useIdleLock } from "@/composables/useIdleLock";
 
 // Components
 import Sidebar from "@/components/Sidebar.vue";
@@ -24,9 +26,12 @@ import CalculatorsView from "@/views/calculators/CalculatorsView.vue";
   
 const store = useFinanceStore();
 const settingsStore = useSettingsStore();
+const auth = useAuthStore();
 
 // The app stays gated behind the master-password screen until it is unlocked.
 const authUnlocked = ref(false);
+// One-time app setup runs on the first unlock; later unlocks (after a lock) skip it.
+const appInitialized = ref(false);
 
 // Current view
 type ViewName = "dashboard" | "transactions" | "categories" | "settings" | "accounts" | "insights" | "recurring" | "investments" | "investment-insights" | "calculators";
@@ -90,12 +95,24 @@ onMounted(() => {
   settingsStore.loadSettings();
 });
 
-// Runs once the master password unlocks the database (emitted by the gate).
+// Runs each time the gate unlocks. One-time setup happens on the first unlock;
+// later unlocks (after a lock) only refresh data that may have changed.
 async function onUnlocked() {
   authUnlocked.value = true;
   // Let the main UI (and its modal refs) mount before using them.
   await nextTick();
 
+  if (!appInitialized.value) {
+    appInitialized.value = true;
+    await initializeApp();
+  } else {
+    await refreshAfterUnlock();
+  }
+}
+
+// One-time setup after the first successful unlock: load preferences, wire up
+// background-event listeners and timers, and pull initial data.
+async function initializeApp() {
   await settingsStore.loadBackupSettings();
   await settingsStore.loadAppPreferences();
 
@@ -123,8 +140,10 @@ async function onUnlocked() {
   await store.fetchInvestmentHoldings();
   store.refreshInvestmentPrices();
 
-  // Refresh investment prices every 30 minutes
+  // Refresh investment prices every 30 minutes (skipped while locked — the DB is
+  // closed and persisting quotes would throw).
   window.setInterval(() => {
+    if (!authUnlocked.value) return;
     store.refreshInvestmentPrices();
   }, 30 * 60 * 1000);
 
@@ -160,6 +179,11 @@ async function onUnlocked() {
     currentView.value = "investments";
   });
 
+  // The main process re-locks on OS suspend / screen lock; reflect that here.
+  window.electronAPI.onAppLocked(() => {
+    auth.markLocked();
+  });
+
   // Mirror locale/currency to the main process so reminder notifications match the user's region
   const syncReminderLocale = () => {
     void window.electronAPI.setReminderLocale(settingsStore.resolvedLocale, settingsStore.currency);
@@ -171,12 +195,39 @@ async function onUnlocked() {
   window.addEventListener("keydown", handleKeydown);
 }
 
+// After re-unlocking (post-lock), the background heartbeat resumes and may have
+// caught up on recurring transactions / savings interest; pull the latest data.
+async function refreshAfterUnlock() {
+  await store.fetchRecurringTransactions();
+  await store.fetchTransactions(store.currentLedgerMonth, store.selectedYear ?? undefined);
+  await store.fetchAccounts();
+  store.fetchPeriodSummarySync();
+}
+
 onUnmounted(() => {
   window.removeEventListener("keydown", handleKeydown);
 });
 
+// Auto-lock on inactivity (Off when autoLockMinutes is 0). Disarms automatically
+// while locked because `enabled` (authUnlocked) is false.
+useIdleLock({
+  enabled: authUnlocked,
+  timeoutMs: computed(() => settingsStore.autoLockMinutes * 60 * 1000),
+  onIdle: () => void auth.lock(),
+});
+
+// Every lock path clears auth.isUnlocked (manual, idle, or OS-initiated); drop
+// back to the gate whenever that happens.
+watch(
+  () => auth.isUnlocked,
+  (unlocked) => {
+    if (!unlocked) authUnlocked.value = false;
+  },
+);
+
 // Keyboard shortcuts
 function handleKeydown(e: KeyboardEvent) {
+  if (!authUnlocked.value) return;
   if (e.ctrlKey || e.metaKey) {
     switch (e.key.toLowerCase()) {
       case "n":
@@ -201,7 +252,11 @@ function handleKeydown(e: KeyboardEvent) {
               break;
             case "l":
               e.preventDefault();
-              currentView.value = "categories";
+              if (e.shiftKey) {
+                void auth.lock();
+              } else {
+                currentView.value = "categories";
+              }
               break;
             case "a":
               if (e.shiftKey) {
@@ -234,6 +289,7 @@ function handleKeydown(e: KeyboardEvent) {
 <template>
   <MasterPasswordGate
     v-if="!authUnlocked"
+    :allow-auto-unlock="!appInitialized"
     @unlocked="onUnlocked"
   />
   <div

--- a/src/composables/useIdleLock.ts
+++ b/src/composables/useIdleLock.ts
@@ -1,0 +1,51 @@
+import { watch, onUnmounted, type Ref } from "vue";
+
+// User activity that resets the idle countdown. Listeners are passive so they
+// never interfere with scrolling.
+const ACTIVITY_EVENTS = ["mousemove", "mousedown", "keydown", "wheel", "touchstart", "scroll"] as const;
+
+// Calls `onIdle` after `timeoutMs` of no user activity. Active only while
+// `enabled` is true and `timeoutMs` > 0; any tracked activity restarts the timer.
+// Re-evaluates whenever `enabled` or `timeoutMs` changes (e.g. lock/unlock, or the
+// user changing the auto-lock setting).
+export function useIdleLock(opts: {
+  enabled: Ref<boolean>;
+  timeoutMs: Ref<number>;
+  onIdle: () => void;
+}): void {
+  let timer: number | null = null;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = () => {
+    clearTimer();
+    if (!opts.enabled.value || opts.timeoutMs.value <= 0) return;
+    timer = window.setTimeout(() => opts.onIdle(), opts.timeoutMs.value);
+  };
+
+  const attach = () => ACTIVITY_EVENTS.forEach((e) => window.addEventListener(e, schedule, { passive: true }));
+  const detach = () => ACTIVITY_EVENTS.forEach((e) => window.removeEventListener(e, schedule));
+
+  watch(
+    [opts.enabled, opts.timeoutMs],
+    ([enabled]) => {
+      detach();
+      clearTimer();
+      if (enabled) {
+        attach();
+        schedule();
+      }
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(() => {
+    detach();
+    clearTimer();
+  });
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -68,6 +68,20 @@ export const useAuthStore = defineStore("auth", () => {
     return window.electronAPI.changeMasterPassword(oldPassword, newPassword);
   }
 
+  // Re-lock the session: clears the in-memory passphrase in Main and re-locks the
+  // database. The gate reappears; re-unlocking uses the normal unlock flow (and
+  // deliberately skips the remembered-key auto-unlock so a lock isn't undone).
+  async function lock(): Promise<void> {
+    await window.electronAPI.lock();
+    isUnlocked.value = false;
+  }
+
+  // Reflect a lock initiated by the main process (e.g. OS sleep / screen lock),
+  // where the database has already been closed — just sync the renderer state.
+  function markLocked(): void {
+    isUnlocked.value = false;
+  }
+
   return {
     hasMasterPassword,
     isUnlocked,
@@ -79,5 +93,7 @@ export const useAuthStore = defineStore("auth", () => {
     unlock,
     setRememberPolicy,
     changePassword,
+    lock,
+    markLocked,
   };
 });

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -36,6 +36,7 @@ export const useSettingsStore = defineStore('settings', () => {
   // App preferences — persisted via IPC to app-preferences.json in main process
   const minimizeToTray = ref(false);
   const openAtLogin = ref(false);
+  const autoLockMinutes = ref(0); // 0 = never auto-lock on idle
   let _appPreferencesLoaded = false;
 
   const resolvedRegion = computed(() => {
@@ -106,6 +107,7 @@ export const useSettingsStore = defineStore('settings', () => {
     _appPreferencesLoaded = false;
     minimizeToTray.value = prefs.minimizeToTray;
     openAtLogin.value = prefs.openAtLogin;
+    autoLockMinutes.value = prefs.autoLockMinutes;
     _appPreferencesLoaded = true;
   };
 
@@ -136,11 +138,12 @@ export const useSettingsStore = defineStore('settings', () => {
     }).catch(console.error);
   });
 
-  watch([minimizeToTray, openAtLogin], ([tray, login]) => {
+  watch([minimizeToTray, openAtLogin, autoLockMinutes], ([tray, login, autoLock]) => {
     if (!_appPreferencesLoaded) return;
     void window.electronAPI.saveAppPreferences({
       minimizeToTray: tray,
       openAtLogin: login,
+      autoLockMinutes: autoLock,
     }).catch(console.error);
   });
 
@@ -165,6 +168,7 @@ export const useSettingsStore = defineStore('settings', () => {
     // App preferences
     minimizeToTray,
     openAtLogin,
+    autoLockMinutes,
     loadAppPreferences,
   };
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,3 +201,13 @@ export const REMEMBER_POLICY_OPTIONS: { value: RememberPolicy; label: string }[]
   { value: '1d', label: '1 day' },
   { value: '1w', label: '1 week' },
 ];
+
+// Idle auto-lock timeout in minutes; 0 = never auto-lock. Persisted in
+// app-preferences.json; consumed by the renderer's useIdleLock composable.
+export const AUTO_LOCK_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: 'Off' },
+  { value: 5, label: '5 minutes' },
+  { value: 15, label: '15 minutes' },
+  { value: 30, label: '30 minutes' },
+  { value: 60, label: '1 hour' },
+];

--- a/src/views/auth/MasterPasswordGate.vue
+++ b/src/views/auth/MasterPasswordGate.vue
@@ -5,6 +5,13 @@ import PasswordInput from "@/components/PasswordInput.vue";
 
 const emit = defineEmits<{ (e: "unlocked"): void }>();
 
+// When the gate reappears after a mid-session lock (idle / manual / OS lock), the
+// remembered-key auto-unlock is suppressed — otherwise it would instantly undo the
+// lock. Only the first launch allows auto-unlock.
+const props = withDefaults(defineProps<{ allowAutoUnlock?: boolean }>(), {
+  allowAutoUnlock: true,
+});
+
 const auth = useAuthStore();
 
 const loading = ref(true);
@@ -24,7 +31,8 @@ onMounted(async () => {
     return;
   }
   // Returning user within a still-valid remember-window → open without prompting.
-  if (auth.hasMasterPassword) {
+  // Skipped after a mid-session lock so the lock isn't immediately undone.
+  if (auth.hasMasterPassword && props.allowAutoUnlock) {
     const auto = await auth.tryAutoUnlock();
     if (auto.success) {
       emit("unlocked");

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -8,7 +8,7 @@ import ChangePasswordModal from "./components/ChangePasswordModal.vue";
 import { useDataManagement } from "@/composables/useDataManagement";
 import { useSettingsStore, regionalSettings } from "@/stores/settings";
 import { useAuthStore } from "@/stores/auth";
-import { REMEMBER_POLICY_OPTIONS, type RememberPolicy } from "@/types";
+import { REMEMBER_POLICY_OPTIONS, AUTO_LOCK_OPTIONS, type RememberPolicy } from "@/types";
 import Select from "primevue/select";
 import lockupMacDark from "@/assets/onefinance_lockup_mac_dark.png";
 import lockupMacLight from "@/assets/onefinance_lockup_mac_light.png";
@@ -45,6 +45,11 @@ const rememberPolicy = computed<RememberPolicy>({
   set: (value) => { void auth.setRememberPolicy(value); },
 });
 
+// Manually lock the app now → returns to the master-password gate.
+function lockNow() {
+  void auth.lock();
+}
+
 const isDev = import.meta.env.DEV;
 
 const {
@@ -67,6 +72,7 @@ const shortcuts = [
   { keys: ["Ctrl", "Shift", "I"], description: "Go to Investments" },
   { keys: ["Ctrl", "Shift", "S"], description: "Go to Settings" },
   { keys: ["Ctrl", "Shift", "P"], description: "Toggle Privacy Mode" },
+  { keys: ["Ctrl", "Shift", "L"], description: "Lock OneFinance" },
   { keys: ["/"], description: "Go to Search Bar (While on Transactions Page)" },
 ];
 
@@ -337,7 +343,7 @@ async function runBackupNow() {
           <i class="pi pi-lock mr-2 text-gray-700 dark:text-white" />
           Security
         </h3>
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
           Manage the master password that encrypts your data and how long OneFinance stays unlocked.
         </p>
 
@@ -348,10 +354,10 @@ async function runBackupNow() {
               <i class="pi pi-key text-primary-500" />
               Master Password
             </div>
-            <p class="text-xs text-gray-500 mb-4">
+            <p class="text-xs text-gray-500 mb-3">
               The password that encrypts your data
             </p>
-            <div class="mt-auto">
+            <div>
               <button
                 class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
                 @click="changePasswordModal?.open()"
@@ -368,10 +374,10 @@ async function runBackupNow() {
               <i class="pi pi-clock text-primary-500" />
               Stay Unlocked
             </div>
-            <p class="text-xs text-gray-500 mb-4">
+            <p class="text-xs text-gray-500 mb-3">
               How long before asking for your password again
             </p>
-            <div class="mt-auto">
+            <div>
               <Select
                 v-if="auth.canRemember"
                 v-model="rememberPolicy"
@@ -386,6 +392,33 @@ async function runBackupNow() {
               >
                 Unavailable — no secure keychain on this system, so OneFinance always asks on launch.
               </p>
+            </div>
+          </div>
+
+          <!-- Auto-Lock -->
+          <div class="flex flex-col bg-gray-50 dark:bg-gray-900/50 p-4 rounded-xl border border-gray-100 dark:border-gray-800 transition-all">
+            <div class="flex items-center gap-2 mb-1 text-sm font-bold text-gray-800 dark:text-gray-200">
+              <i class="pi pi-lock-open text-primary-500" />
+              Auto-Lock
+            </div>
+            <p class="text-xs text-gray-500 mb-3">
+              Lock automatically after a period of inactivity
+            </p>
+            <div class="flex items-center gap-2">
+              <Select
+                v-model="settingsStore.autoLockMinutes"
+                :options="AUTO_LOCK_OPTIONS"
+                option-label="label"
+                option-value="value"
+                class="flex-1"
+              />
+              <button
+                class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors whitespace-nowrap"
+                @click="lockNow"
+              >
+                <i class="pi pi-lock mr-1.5" />
+                Lock Now
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary of Changes

This pull request adds robust session auto-locking to the application, enhancing security by locking the database automatically on OS suspend, screen lock, manual request, or after a configurable period of user inactivity. It introduces new preferences and UI wiring to support these features, along with corresponding updates to the main process, renderer, and shared state.

**Session Auto-Lock and Security Enhancements:**

* Added support for auto-locking the session on OS suspend or screen lock events by listening to Electron's `powerMonitor` events and re-locking the database accordingly. The renderer is notified to show the master-password gate when this occurs. (`electron/main.ts`, [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR413-R427) [[2]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR638) [[3]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR654)
* Implemented a manual lock mechanism accessible from the renderer, which clears the in-memory passphrase, closes the database, and disables auto-unlock until the password is re-entered. (`electron/main.ts`, [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR469-R477) [[2]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR604-R611); `src/stores/auth.ts`, [[3]](diffhunk://#diff-66414755f085c340c189857caf3dcfb6b2e18bc6ab17c5926a61651898330a1dR71-R84) [[4]](diffhunk://#diff-66414755f085c340c189857caf3dcfb6b2e18bc6ab17c5926a61651898330a1dR96-R97); `electron/preload.ts`, [[5]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bR295-R301)
* Added a composable (`useIdleLock`) in the renderer that auto-locks the session after a user-configurable period of inactivity, with options surfaced in app preferences. (`src/composables/useIdleLock.ts`, [[1]](diffhunk://#diff-f800475c8060842dfe78bcfe756b9446ff8234c37d138d3c49905ab218cd5663R1-R51); `src/App.vue`, [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R198-R230) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R29-R34) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L93-R115) [[5]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R182-R186) [[6]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R255-R259) [[7]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R292); `src/types.ts`, [[8]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR204-R213)

**Preferences and State Management:**

* Extended `AppPreferences` and related state to include `autoLockMinutes`, allowing users to configure the idle timeout (including "Off"). Preferences are persisted and synchronized between main and renderer. (`electron/preferences.ts`, [[1]](diffhunk://#diff-13bc0e53fd39bf68452da090e4f73d0e238082f05142c1cfde3d1cd2b813f723R11-R18); `src/stores/settings.ts`, [[2]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7R39) [[3]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7R110) [[4]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7L139-R146) [[5]](diffhunk://#diff-d8d523dfd1e392340443844d193c47b2f06bde1a204fd31f1316ff9d6a53d3f7R171)

**UI and User Experience:**

* Updated the master password gate to suppress auto-unlock after a mid-session lock, ensuring that a deliberate lock isn't immediately undone by the remembered key. (`src/views/auth/MasterPasswordGate.vue`, [[1]](diffhunk://#diff-501ff0b8f58c424ae55efbc328a8b38c710c79cdb308f6088bd12fe3532f6d97R8-R14) [[2]](diffhunk://#diff-501ff0b8f58c424ae55efbc328a8b38c710c79cdb308f6088bd12fe3532f6d97L27-R35); `src/App.vue`, [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R292)
* Added keyboard shortcut (Ctrl/Cmd+Shift+L) to manually lock the session from the UI. (`src/App.vue`, [src/App.vueR255-R259](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R255-R259))

**Background Task Coordination:**

* Ensured that background tasks (recurring transactions, investment price refresh) are paused while the session is locked and resume with fresh data upon unlocking. (`electron/main.ts`, [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR398-R399); `src/App.vue`, [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L126-R146) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R198-R230)

These changes significantly improve the security posture of the application by reducing the risk of an unlocked session being exposed when the user is away, while providing flexible and user-friendly controls for session locking.
